### PR TITLE
Misnamed property for the exec-query-view action

### DIFF
--- a/installCatalog.sh
+++ b/installCatalog.sh
@@ -150,7 +150,7 @@ $WSK_CLI -i --apihost "$APIHOST" action update --auth "$AUTH" --shared yes cloud
 $WSK_CLI -i --apihost "$APIHOST" action update --auth "$AUTH" --shared yes cloudant/exec-query-view \
     "$PACKAGE_HOME/actions/database-actions/exec-query-view.js" \
     -a description 'Call view in design document from database' \
-    -a parameters '[ {"name":"dbname", "required":true}, {"name":"docid", "required":true}, {"name":"view", "required":true}, {"name":"params", "required":false} ]' \
+    -a parameters '[ {"name":"dbname", "required":true}, {"name":"docid", "required":true}, {"name":"viewname", "required":true}, {"name":"params", "required":false} ]' \
     -p docid '' \
     -p viewname ''
 


### PR DESCRIPTION
A property annotation for the exec-query-view action incorrectly specifies view instead of viewname.

Fixes issue #18 